### PR TITLE
Less repetitive persistence

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -176,10 +176,13 @@ func (c *Collector) recursivelyGather(response eventsResponse) ([]resource, erro
 		return data, fmt.Errorf("unable to unmarshal authentication response: %s", err)
 	}
 
+	// FIXME: Remove this when there is a persistance for the LastSeenGUID...
+	someHoursAgo := time.Now().Add(-1 * 6 * time.Hour)
+
 	for i, event := range newResponse.Resources {
 		// FIXME: The weird `CreatedAt` based check can go away as soon as there is a persistance for the LastSeenGUID...
 		log.Println(event.CreatedAt)
-		if event.GUID == c.LastSeenGUID || event.CreatedAt.Before(time.Date(2019, 11, 18, 0, 0, 0, 0, time.UTC)) {
+		if event.GUID == c.LastSeenGUID || event.CreatedAt.Before(someHoursAgo) {
 			return append(data, newResponse.Resources[:i]...), nil
 		}
 	}

--- a/collector.go
+++ b/collector.go
@@ -181,8 +181,8 @@ func (c *Collector) recursivelyGather(response eventsResponse) ([]resource, erro
 
 	for i, event := range newResponse.Resources {
 		// FIXME: The weird `CreatedAt` based check can go away as soon as there is a persistance for the LastSeenGUID...
-		log.Println(event.CreatedAt)
 		if event.GUID == c.LastSeenGUID || event.CreatedAt.Before(someHoursAgo) {
+			log.Printf("Shipped until %s\n", event.CreatedAt)
 			return append(data, newResponse.Resources[:i]...), nil
 		}
 	}


### PR DESCRIPTION
What
----

Now that we are shipping events using a CF app, it is likely the app is going to be restarted.

When it is restarted, it should only ship a minimally small set of logs, which is currently not the case.

This PR changes it to only duplicate the last 6 hours of events. Which shouldn't be too many duplications.

How to review
----

Code review

Who can review
----

Not @tlwr